### PR TITLE
add a check of the hartid so we only print on processor #0

### DIFF
--- a/hello.s
+++ b/hello.s
@@ -6,6 +6,8 @@
 .globl _start
 
 _start:
+        csrr a1, mhartid             # read our hartid and only run on processor 0
+        bne a1, zero, 3f
 1:      auipc a0, %pcrel_hi(msg)     # load msg(hi)
         addi  a0, a0, %pcrel_lo(1b)  # load msg(lo)
 2:      jal   ra, puts


### PR DESCRIPTION
This is a pretty simple change to fix the problem with printing the string multiple times. It just makes it run only one 1 core.